### PR TITLE
Switch to buildpacks instead of Dockerfile

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,16 +11,7 @@ builds:
       - arm64
 dockers:
   - image_templates: ["ghcr.io/salesforce/ci-result-to-slack:{{ .Version }}"]
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - --label=org.opencontainers.image.title={{ .ProjectName }}
-      - --label=org.opencontainers.image.description={{ .ProjectName }}
-      - --label=org.opencontainers.image.url=https://github.com/salesforce/ci-result-to-slack
-      - --label=org.opencontainers.image.source=https://github.com/salesforce/ci-result-to-slack
-      - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
-      - --label=org.opencontainers.image.revision={{ .FullCommit }}
-      - --label=org.opencontainers.image.licenses=BSD-3-Clause
+    use: buildpacks
 nfpms:
   - maintainer: Justin Harringa <jharringa@salesforce.com>
     description: Send your CI result to Slack upon pipeline completion

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,19 @@
 project_name: ci-result-to-slack
+env:
+  - BP_OCI_TITLE={{ .ProjectName }}
+  - BP_OCI_AUTHORS=Justin Harringa <jharringa@salesforce.com>
+  - BP_OCI_DESCRIPTION=Send your CI result to Slack upon pipeline completion
+  - BP_OCI_URL=https://github.com/salesforce/ci-result-to-slack
+  - BP_OCI_SOURCE=https://github.com/salesforce/ci-result-to-slack
+  - BP_OCI_DOCUMENTATION=https://github.com/salesforce/ci-result-to-slack/blob/main/README.md
+  - BP_OCI_REVISION={{ .FullCommit }}
+  - BP_OCI_VERSION={{ .Version }}
+  - BP_OCI_CREATED={{ time "2006-01-02T15:04:05Z07:00" }}
+  - BP_OCI_LICENSES=BSD-3-Clause
+  - BP_OCI_VENDOR=Salesforce.com
 builds:
-  - env: [CGO_ENABLED=0]
+  - env: 
+      - CGO_ENABLED=0
     main: ./cmd/ci-result-to-slack
     goos:
       - linux
@@ -12,6 +25,20 @@ builds:
 dockers:
   - image_templates: ["ghcr.io/salesforce/ci-result-to-slack:{{ .Version }}"]
     use: buildpacks
+    build_flag_templates:
+    - --env=BP_OCI_TITLE
+    - --env=BP_OCI_AUTHORS
+    - --env=BP_OCI_DESCRIPTION
+    - --env=BP_OCI_URL
+    - --env=BP_OCI_SOURCE
+    - --env=BP_OCI_DOCUMENTATION
+    - --env=BP_OCI_VERSION
+    - --env=BP_OCI_VENDOR
+    - --env=BP_OCI_CREATED
+    - --env=BP_OCI_REVISION
+    - --env=BP_OCI_LICENSES
+    - --env=BP_OCI_URL
+    - --buildpack=gcr.io/paketo-buildpacks/image-labels
 nfpms:
   - maintainer: Justin Harringa <jharringa@salesforce.com>
     description: Send your CI result to Slack upon pipeline completion

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM gcr.io/distroless/base-debian11
-
-COPY ./ci-result-to-slack /ci-result-to-slack
-
-ENTRYPOINT ["/ci-result-to-slack"]

--- a/project.toml
+++ b/project.toml
@@ -1,0 +1,9 @@
+[project]
+id = "com.salesforce.ci-result-to-slack"
+name = "ci-result-to-slack"
+authors = ["Justin Harringa"]
+documentation-url = "https://github.com/salesforce/ci-result-to-slack#readme"
+source-url = "https://github.com/salesforce/ci-result-to-slack"
+
+[[project.licenses]]
+type = "BSD-3-Clause"


### PR DESCRIPTION
Primary thing we lose with this change is our org.opencontainers.image
labels. See https://github.com/buildpacks/community/discussions/101 for
efforts in the community around this. Perhaps hold on this for now?