### PR TITLE
Add slackAPI interface and inject dependencies for coverage

### DIFF
--- a/internal/slack.go
+++ b/internal/slack.go
@@ -25,11 +25,19 @@ type slackClient interface {
 	postWebhookMessage(buildInfo BuildInfo) error
 }
 
+type slackAPI interface {
+	PostMessage(channelID string, options ...slack.MsgOption) (string, string, error)
+}
+
+var _ slackAPI = (*slack.Client)(nil)
+
 type productionSlackClientWorker struct {
+	apiFactory    func(token string) slackAPI
+	webhookPoster func(url string, msg *slack.WebhookMessage) error
 }
 
 func (client *productionSlackClientWorker) postChannelMessage(buildInfo BuildInfo) error {
-	api := slack.New(buildInfo.OauthToken)
+	api := client.apiFactory(buildInfo.OauthToken)
 	postMessage := getPostMessage(buildInfo, buildInfo.GetContextualStatus())
 	_, _, err := api.PostMessage(buildInfo.DestChannelId, postMessage...)
 	return err
@@ -37,7 +45,7 @@ func (client *productionSlackClientWorker) postChannelMessage(buildInfo BuildInf
 
 func (client *productionSlackClientWorker) postWebhookMessage(buildInfo BuildInfo) error {
 	message := getWebhookMessage(buildInfo, buildInfo.GetContextualStatus())
-	err := slack.PostWebhook(buildInfo.HookURL, &message)
+	err := client.webhookPoster(buildInfo.HookURL, &message)
 	return err
 }
 
@@ -87,7 +95,10 @@ func (client *SlackClient) PostToSlack(buildInfo BuildInfo) error {
 }
 
 func NewSlackClient() SlackClient {
-	return SlackClient{&productionSlackClientWorker{}}
+	return SlackClient{&productionSlackClientWorker{
+		apiFactory:    func(token string) slackAPI { return slack.New(token) },
+		webhookPoster: slack.PostWebhook,
+	}}
 }
 
 func getPostMessage(buildInfo BuildInfo, buildStatus Status) []slack.MsgOption {

--- a/internal/slack_test.go
+++ b/internal/slack_test.go
@@ -318,6 +318,107 @@ func Test_getPostMessage(t *testing.T) {
 	// This ensures the function executes and returns the expected slice structure
 }
 
+// fakeSlackAPI is a test double for the slackAPI interface.
+type fakeSlackAPI struct {
+	capturedChannelID string
+	capturedOptions   []slack.MsgOption
+	err               error
+}
+
+func (f *fakeSlackAPI) PostMessage(channelID string, options ...slack.MsgOption) (string, string, error) {
+	f.capturedChannelID = channelID
+	f.capturedOptions = options
+	return "", "", f.err
+}
+
+func Test_productionSlackClientWorker_postChannelMessage(t *testing.T) {
+	t.Run("calls PostMessage with correct channelID and non-empty options", func(t *testing.T) {
+		fakeAPI := &fakeSlackAPI{}
+		worker := &productionSlackClientWorker{
+			apiFactory: func(token string) slackAPI { return fakeAPI },
+		}
+		buildInfo := BuildInfo{
+			JobName:       "test-job",
+			BuildURL:      "https://example.com",
+			BuildStatus:   successKey,
+			OauthToken:    "token",
+			DestChannelId: "C12345",
+		}
+		err := worker.postChannelMessage(buildInfo)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if fakeAPI.capturedChannelID != "C12345" {
+			t.Errorf("expected channelID %q, got %q", "C12345", fakeAPI.capturedChannelID)
+		}
+		if len(fakeAPI.capturedOptions) == 0 {
+			t.Error("expected non-empty message options")
+		}
+	})
+
+	t.Run("propagates error from PostMessage", func(t *testing.T) {
+		fakeAPI := &fakeSlackAPI{err: fmt.Errorf("api error")}
+		worker := &productionSlackClientWorker{
+			apiFactory: func(token string) slackAPI { return fakeAPI },
+		}
+		buildInfo := BuildInfo{
+			OauthToken:    "token",
+			DestChannelId: "C12345",
+			BuildStatus:   successKey,
+		}
+		err := worker.postChannelMessage(buildInfo)
+		if err == nil || err.Error() != "api error" {
+			t.Errorf("expected 'api error', got %v", err)
+		}
+	})
+}
+
+func Test_productionSlackClientWorker_postWebhookMessage(t *testing.T) {
+	t.Run("calls webhookPoster with correct URL and non-nil message", func(t *testing.T) {
+		var capturedURL string
+		var capturedMsg *slack.WebhookMessage
+		worker := &productionSlackClientWorker{
+			webhookPoster: func(url string, msg *slack.WebhookMessage) error {
+				capturedURL = url
+				capturedMsg = msg
+				return nil
+			},
+		}
+		buildInfo := BuildInfo{
+			JobName:     "test-job",
+			BuildURL:    "https://example.com",
+			BuildStatus: successKey,
+			HookURL:     "https://hooks.slack.com/test",
+		}
+		err := worker.postWebhookMessage(buildInfo)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if capturedURL != "https://hooks.slack.com/test" {
+			t.Errorf("expected URL %q, got %q", "https://hooks.slack.com/test", capturedURL)
+		}
+		if capturedMsg == nil {
+			t.Error("expected non-nil webhook message")
+		}
+	})
+
+	t.Run("propagates error from webhookPoster", func(t *testing.T) {
+		worker := &productionSlackClientWorker{
+			webhookPoster: func(url string, msg *slack.WebhookMessage) error {
+				return fmt.Errorf("webhook error")
+			},
+		}
+		buildInfo := BuildInfo{
+			HookURL:     "https://hooks.slack.com/test",
+			BuildStatus: successKey,
+		}
+		err := worker.postWebhookMessage(buildInfo)
+		if err == nil || err.Error() != "webhook error" {
+			t.Errorf("expected 'webhook error', got %v", err)
+		}
+	})
+}
+
 func Test_NewSlackClient(t *testing.T) {
 	client := NewSlackClient()
 	if client.slackClient == nil {
@@ -384,6 +485,31 @@ func Test_PostToSlack_EdgeCases(t *testing.T) {
 			NewTestClient(false, false),
 			true,
 			PickRunModeErrorMessage,
+		},
+		{
+			"channel message client returns error - PostToSlack propagates it",
+			BuildInfo{
+				JobName:       "job",
+				BuildURL:      "url",
+				BuildStatus:   "SUCCESS",
+				OauthToken:    "token",
+				DestChannelId: "channel",
+			},
+			NewTestClient(true, false),
+			true,
+			ChannelMessageTestErr,
+		},
+		{
+			"webhook client returns error - PostToSlack propagates it",
+			BuildInfo{
+				JobName:     "job",
+				BuildURL:    "url",
+				BuildStatus: "SUCCESS",
+				HookURL:     "https://hooks.slack.com/test",
+			},
+			NewTestClient(false, true),
+			true,
+			WebhookMessageTestErr,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Extracts a `slackAPI` interface mirroring `slack.Client.PostMessage` and adds a compile-time assertion (`var _ slackAPI = (*slack.Client)(nil)`) so any future breaking change to the `slack-go/slack` API fails the build immediately
- Injects `apiFactory` and `webhookPoster` function fields into `productionSlackClientWorker`, replacing direct calls to `slack.New` and `slack.PostWebhook`
- Adds tests for `productionSlackClientWorker` covering success and error paths for both `postChannelMessage` and `postWebhookMessage`
- Adds two error-propagation cases to `Test_PostToSlack_EdgeCases` using `NewTestClient(true, false)` and `NewTestClient(false, true)`

## Test plan

- [x] `go build ./...` passes (compile-time guard verified)
- [x] `go test -race ./...` passes with no failures
- [x] `postChannelMessage` (production): 0% → 100%
- [x] `postWebhookMessage` (production): 0% → 100%
- [x] Overall coverage: ~78% → 92%