### PR TITLE
fix: add missing OCI labels and fix description in .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,9 +15,12 @@ dockers:
     dockerfile: Dockerfile
     build_flag_templates:
       - --label=org.opencontainers.image.title={{ .ProjectName }}
-      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.description=Send your CI result to Slack upon pipeline completion
+      - --label=org.opencontainers.image.authors=Justin Harringa <jharringa@salesforce.com>
+      - --label=org.opencontainers.image.vendor=Salesforce.com
       - --label=org.opencontainers.image.url=https://github.com/salesforce/ci-result-to-slack
       - --label=org.opencontainers.image.source=https://github.com/salesforce/ci-result-to-slack
+      - --label=org.opencontainers.image.documentation=https://github.com/salesforce/ci-result-to-slack/blob/main/README.md
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}


### PR DESCRIPTION
## Summary

- Fix `org.opencontainers.image.description` — was incorrectly set to `{{ .ProjectName }}` (rendered as `ci-result-to-slack`); now uses the actual description string (consistent with `nfpms.description`)
- Add `org.opencontainers.image.authors` (consistent with `nfpms.maintainer`)
- Add `org.opencontainers.image.vendor`
- Add `org.opencontainers.image.documentation`

These were identified during evaluation of PR #12 (now closed) as the only substantive additions worth carrying forward from that approach.

## Test plan

- [ ] CI passes (goreleaser config is validated in the release workflow on tag push)
- [ ] On next release, verify the published image at `ghcr.io/salesforce/ci-result-to-slack` has the expected labels via `docker inspect` or `crane inspect`