### PR TITLE
docs: document release process and add GitHub release notes config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,17 @@
+documentation:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              - '*.md'
+              - 'docs/**'
+
+chore:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              - '.github/**'
+              - 'Makefile'
+              - 'go.mod'
+              - 'go.sum'
+              - '*.yml'
+              - '*.yaml'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - question
+      - wontfix
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Dependency Updates
+      labels:
+        - dependabot
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,21 +6,21 @@ changelog:
       - question
       - wontfix
   categories:
-    - title: Breaking Changes
+    - title: "⚠️ Breaking Changes"
       labels:
         - breaking-change
-    - title: New Features
+    - title: "🎉 New Features"
       labels:
         - enhancement
-    - title: Bug Fixes
+    - title: "🐛 Bug Fixes"
       labels:
         - bug
-    - title: Documentation
+    - title: "📖 Documentation"
       labels:
         - documentation
-    - title: Dependency Updates
+    - title: "📦 Dependency Updates"
       labels:
         - dependabot
-    - title: Other Changes
+    - title: "🔧 Other Changes"
       labels:
         - "*"

--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -1,0 +1,17 @@
+name: Auto Label
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  autolabel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -61,5 +61,45 @@ If you right-click on the channel / messages, you can hit `Copy Link` and also s
 (e.g. `https://${YOUR_WORKSPACE}.slack.com/messages/${DEST_CHANNEL_ID}`)
 
 ## Slack Incoming Webhooks
-To get the `HOOK_URL` for Incoming Webhooks, you'll follow 
+To get the `HOOK_URL` for Incoming Webhooks, you'll follow
 [Slack's Incoming Webhooks instructions](https://api.slack.com/incoming-webhooks).
+
+# Releasing
+
+Releases are triggered by pushing a tag. The [release workflow](.github/workflows/release.yml) runs
+[GoReleaser](https://goreleaser.com/) on any tag push, which builds binaries, publishes packages
+(deb/rpm/apk), and pushes the Docker image to `ghcr.io/salesforce/ci-result-to-slack`.
+Release notes are automatically generated from merged PRs using [`.github/release.yml`](.github/release.yml).
+
+## Cutting a release
+
+```sh
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+## Choosing a version
+
+This project uses [semantic versioning](https://semver.org). Choose the next version based on
+what has changed since the last release:
+
+- `PATCH` (e.g. `v1.2.3`) — bug fixes, dependency bumps, documentation
+- `MINOR` (e.g. `v1.3.0`) — new backwards-compatible functionality
+- `MAJOR` (e.g. `v2.0.0`) — breaking changes
+
+To see the latest tag: `git describe --tags --abbrev=0`
+
+Optionally, [`svu`](https://github.com/caarlos0/svu) can calculate the next version automatically
+from [conventional commits](https://www.conventionalcommits.org/):
+
+```sh
+# Install
+brew install caarlos0/tap/svu
+
+# Show what the next version would be
+svu next
+
+# Tag and push
+git tag "$(svu next)"
+git push origin "$(svu next)"
+```


### PR DESCRIPTION
## Summary

- Add a **Releasing** section to the README explaining:
  - How releases are triggered (tag push → goreleaser)
  - How to cut a release manually
  - Semantic versioning guidance (patch/minor/major)
  - [`svu`](https://github.com/caarlos0/svu) as an optional tool for calculating the next version from conventional commits
- Add `.github/release.yml` to configure [automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes), categorizing PRs by existing repo labels:
  - Breaking Changes (`breaking-change`)
  - New Features (`enhancement`)
  - Bug Fixes (`bug`)
  - Documentation (`documentation`)
  - Dependency Updates (`dependabot`)
  - Other Changes (catch-all)

Closes #14