### PR TITLE
ci: use GitHub native release notes in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 version: 2
 project_name: ci-result-to-slack
+changelog:
+  use: github-native
 builds:
   - env: [CGO_ENABLED=0]
     main: ./cmd/ci-result-to-slack


### PR DESCRIPTION
## Summary

Switches GoReleaser's changelog source to `github-native`, so release notes are generated via GitHub's release notes API rather than raw git log. This makes the categorized `.github/release.yml` config (emoji categories, label-based grouping) take effect on each release.

## Test plan
- [ ] Cut the next release and verify notes are categorized by label rather than showing raw commits