### PR TITLE
ci: declare contents:read on Build + Test workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   build-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `Build + Test` workflow currently doesn't declare a `permissions:` block, so the workflow `GITHUB_TOKEN` falls back to the repository default. The `build-test` job runs:

- `actions/checkout`
- `actions/setup-go`
- `make ci` (the project's Go build + test)
- `goreleaser/goreleaser-action@v7` with `args: release --skip=publish --snapshot --clean` -- a local snapshot build, not a publishing run

So nothing here writes to the GitHub API or pushes to the repo. `permissions: contents: read` at workflow scope captures the actual minimum.

The shape matches the workflow-level permissions blocks already used by `autolabel.yml`, `codeql-analysis.yml`, and `release.yml`. With it set:

- the workflow token can't be widened by a future change to the repo default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for this file
- a hypothetical compromise of `goreleaser/goreleaser-action`, `actions/setup-go`, or `actions/checkout` (cf. tj-actions/changed-files CVE-2025-30066) stays boxed in read-only

`golangci-lint.yaml` is the other workflow without a permissions block but it's 19 lines and below the noise floor for a separate PR.

No behavioural change.